### PR TITLE
Update to Quarkus 3.29, improve config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea/
+target/
+

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
 		<quarkus.platform.group-id>io.quarkus.platform</quarkus.platform.group-id>
-		<quarkus.platform.version>3.25.4</quarkus.platform.version>
+		<quarkus.platform.version>3.29.0</quarkus.platform.version>
 		<surefire-plugin.version>3.5.3</surefire-plugin.version>
 	</properties>
 	<dependencyManagement>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,8 @@
+#Tune these settings for "offline" (no DB), so to measure the overhead of Quarkus & Hibernate processing only:
 quarkus.datasource.devservices.enabled=true
+quarkus.datasource.jdbc.max-size=5
+quarkus.datasource.jdbc.min-size=0
+quarkus.datasource.jdbc.initial-size=0
+quarkus.hibernate-orm.database.start-offline=true
+quarkus.hibernate-orm.schema-management.strategy=none
+quarkus.log.category."org.hibernate.orm.deprecation".level=OFF


### PR DESCRIPTION

I've upgraded to Quarkus 3.29, and tuned the configuration slightly to make measurement of the build-time process a bit more accurate (avoid to low Hibernate warnings and avoid to try connecting to a DB).

The "offline mode" option is not available on older Quarkus versions though, so it's not fully fair to compare with older version.